### PR TITLE
Access apis from local.properties in gradle file

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,9 +23,15 @@ android {
             useSupportLibrary = true
         }
 
+        val properties = Properties()
+        properties.load(project.rootProject.file("local.properties").inputStream())
+        buildConfigField("String", "SUPABASE_ANON_KEY", "\"${properties.getProperty("SUPABASE_ANON_KEY")}\"")
+        buildConfigField("String", "SUPABASE_URL", "\"${properties.getProperty("SUPABASE_URL")}\"")
 
     }
-
+    buildFeatures {
+        buildConfig = true // Enable BuildConfig features
+    }
 
 
     buildTypes {


### PR DESCRIPTION
# Intro

Since this is a kotlin based gradle file which is different than that of groovy based gradle file, it required a different syntax to access `variables` from `local.properties`

## Initialization
Before accessing any variables from `local.properties` we have to access the file input stream using
```kotlin
val properties = Properties()
        properties.load(project.rootProject.file("local.properties").inputStream())
``` 
then we can create a key map for the variable values 
```kotlin
buildConfigField("String", "SUPABASE_ANON_KEY", "\"${properties.getProperty("SUPABASE_ANON_KEY")}\"")
buildConfigField("String", "SUPABASE_URL", "\"${properties.getProperty("SUPABASE_URL")}\"")
```
> [!NOTE]
> Don't forget to enable `buildConfig` in buildFeatures.